### PR TITLE
fix: prevent nil pointer dereference in Addr validation

### DIFF
--- a/internal/conf/network.go
+++ b/internal/conf/network.go
@@ -86,8 +86,9 @@ func (n *Addr) validate() []error {
 	l, err := validateAddr(n.Addr_, false)
 	if err != nil {
 		errors = append(errors, err)
+	} else {
+		n.Addr = *l
 	}
-	n.Addr = *l
 
 	if n.RouterMac_ == "" {
 		errors = append(errors, fmt.Errorf("MAC address is required"))


### PR DESCRIPTION
## Fix

Prevents nil pointer dereference panic in `Addr.validate()` when address validation fails.

**Problem:** When `validateAddr()` returns an error, it also returns `nil` for the address pointer. The code was dereferencing this nil pointer unconditionally, causing a panic.

**Solution:** Only assign `n.Addr` when validation succeeds by wrapping the assignment in an `else` clause.

**Impact:** Commands like `paqet run` and `paqet ping` now return proper validation errors instead of crashing when network address configuration is invalid.