### PR TITLE
fix: use flog consistently and fix nil pointer in config validation

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -1,7 +1,6 @@
 package run
 
 import (
-	"log"
 	"paqet/internal/conf"
 	"paqet/internal/flog"
 
@@ -21,7 +20,7 @@ var Cmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg, err := conf.LoadFromFile(confPath)
 		if err != nil {
-			log.Fatalf("Failed to load configuration: %v", err)
+			flog.Fatalf("Failed to load configuration: %v", err)
 		}
 		initialize(cfg)
 
@@ -34,7 +33,7 @@ var Cmd = &cobra.Command{
 			return
 		}
 
-		log.Fatalf("Failed to load configuration")
+		flog.Fatalf("Failed to load configuration")
 	},
 }
 

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -86,15 +86,18 @@ func (c *Conf) validate() error {
 	if c.Role == "server" {
 		allErrors = append(allErrors, c.Listen.validate()...)
 	} else {
-		allErrors = append(allErrors, c.Server.validate()...)
-		if c.Server.Addr.IP.To4() != nil && c.Network.IPv4.Addr == nil {
-			allErrors = append(allErrors, fmt.Errorf("server address is IPv4, but the IPv4 interface is not configured"))
-		}
-		if c.Server.Addr.IP.To4() == nil && c.Network.IPv6.Addr == nil {
-			allErrors = append(allErrors, fmt.Errorf("server address is IPv6, but the IPv6 interface is not configured"))
-		}
-		if c.Transport.Conn > 1 && c.Network.Port != 0 {
-			allErrors = append(allErrors, fmt.Errorf("only one connection is allowed when a client port is explicitly set"))
+		serverErrs := c.Server.validate()
+		allErrors = append(allErrors, serverErrs...)
+		if len(serverErrs) == 0 {
+			if c.Server.Addr.IP.To4() != nil && c.Network.IPv4.Addr == nil {
+				allErrors = append(allErrors, fmt.Errorf("server address is IPv4, but the IPv4 interface is not configured"))
+			}
+			if c.Server.Addr.IP.To4() == nil && c.Network.IPv6.Addr == nil {
+				allErrors = append(allErrors, fmt.Errorf("server address is IPv6, but the IPv6 interface is not configured"))
+			}
+			if c.Transport.Conn > 1 && c.Network.Port != 0 {
+				allErrors = append(allErrors, fmt.Errorf("only one connection is allowed when a client port is explicitly set"))
+			}
 		}
 	}
 	return writeErr(allErrors)

--- a/internal/flog/flog.go
+++ b/internal/flog/flog.go
@@ -23,18 +23,15 @@ var (
 )
 
 func init() {
-
+	go func() {
+		for msg := range logCh {
+			fmt.Fprint(os.Stdout, msg)
+		}
+	}()
 }
 
 func SetLevel(l int) {
 	minLevel = Level(l)
-	if l != -1 {
-		go func() {
-			for msg := range logCh {
-				fmt.Fprint(os.Stdout, msg)
-			}
-		}()
-	}
 }
 
 func logf(level Level, format string, args ...any) {


### PR DESCRIPTION
- replace std log with flog in run command for consistent log formatting
- start flog consumer goroutine in init to ensure logs are printed before config is loaded
- fix nil pointer dereference in config validation by skipping server address checks when server validation fails