### PR TITLE
ci: add ARM 32-bit (armv7) Linux build to release pipeline

### DIFF
--- a/.github/workflows/build-selfhosted.yml
+++ b/.github/workflows/build-selfhosted.yml
@@ -13,7 +13,7 @@ jobs:
             image: golang:1.25
         strategy:
             matrix:
-                goarch: [amd64, arm64]
+                goarch: [amd64, arm64, arm]
 
         steps:
             - name: Setup Build Environment
@@ -24,6 +24,10 @@ jobs:
                     dpkg --add-architecture arm64
                     apt-get update
                     apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross libpcap-dev:arm64
+                  elif [ "${{ matrix.goarch }}" = "arm" ]; then
+                    dpkg --add-architecture armhf
+                    apt-get update
+                    apt-get install -y --no-install-recommends gcc-arm-linux-gnueabihf libc6-dev-armhf-cross libpcap-dev:armhf
                   else
                     apt-get install -y --no-install-recommends build-essential libpcap-dev
                   fi
@@ -61,6 +65,9 @@ jobs:
                   # Set the C compiler for cross-compilation
                   if [ "$GOARCH" = "arm64" ]; then
                     export CC=aarch64-linux-gnu-gcc
+                  elif [ "$GOARCH" = "arm" ]; then
+                    export CC=arm-linux-gnueabihf-gcc
+                    export GOARM=7
                   fi
 
                   go build -v -a -trimpath \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
             image: golang:1.25
         strategy:
             matrix:
-                goarch: [amd64, arm64]
+                goarch: [amd64, arm64, arm]
 
         steps:
             - name: Setup Build Environment
@@ -27,6 +27,10 @@ jobs:
                     dpkg --add-architecture arm64
                     apt-get update
                     apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross libpcap-dev:arm64
+                  elif [ "${{ matrix.goarch }}" = "arm" ]; then
+                    dpkg --add-architecture armhf
+                    apt-get update
+                    apt-get install -y --no-install-recommends gcc-arm-linux-gnueabihf libc6-dev-armhf-cross libpcap-dev:armhf
                   else
                     apt-get install -y --no-install-recommends build-essential libpcap-dev
                   fi
@@ -64,6 +68,9 @@ jobs:
                   # Set the C compiler for cross-compilation
                   if [ "$GOARCH" = "arm64" ]; then
                     export CC=aarch64-linux-gnu-gcc
+                  elif [ "$GOARCH" = "arm" ]; then
+                    export CC=arm-linux-gnueabihf-gcc
+                    export GOARM=7
                   fi
 
                   go build -v -a -trimpath \


### PR DESCRIPTION
# helpful for old Raspberry Pi devices 

- Add `arm` (armhf/armv7) to the Linux build matrix in both build.yml and build-selfhosted.yml. This installs the armhf cross-compiler and sets CC=arm-linux-gnueabihf-gcc with GOARM=7 for the build step.

