### PR TITLE
feat: implement port hopping for evasion

### DIFF
--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -44,7 +44,7 @@ func sendPacket() {
 	log.Printf("Sending packet from IPv4:%s IPv6:%s to %s via %s...", cfg.Network.IPv4.Addr, cfg.Network.IPv6.Addr, cfg.Server.Addr.String(), cfg.Network.Interface.Name)
 	log.Printf("Payload: \"%s\" (%d bytes)", payload, len(payload))
 
-	if err := sendHandle.Write([]byte(payload), cfg.Server.Addr); err != nil {
+	if err := sendHandle.Write([]byte(payload), cfg.Server.Addr, cfg.Network.Port); err != nil {
 		log.Fatalf("Failed to send packet: %v", err)
 	}
 	log.Printf("Packet sent successfully!")

--- a/example/client.yaml.example
+++ b/example/client.yaml.example
@@ -44,6 +44,17 @@ network:
 # Server connection settings
 server:
   addr: "10.0.0.100:9999"  # CHANGE ME: paqet server address and port
+                           # NOTE: If hopping is enabled, this port is ignored for transport
+                           # and the hopping range is used instead.
+# Port Hopping Configuration (Optional)
+# Periodically changes the destination port to evade detection on fixed ports.
+# The server must be configured with the same range.
+
+hopping:
+  enabled: false      # Enable port hopping
+  interval: 30        # Interval in seconds to change ports
+  min: 20000          # Minimum port number of the range
+  max: 30000          # Maximum port number of the range
 
 # Transport protocol configuration
 transport:
@@ -95,6 +106,7 @@ transport:
     # Buffer settings (optional)
     # smuxbuf: 4194304       # 4MB SMUX buffer
     # streambuf: 2097152     # 2MB stream buffer
+
 
 # Optional Forward Error Correction (FEC) - currently disabled
 # Use these only if you need FEC for very lossy networks:

--- a/example/server.yaml.example
+++ b/example/server.yaml.example
@@ -11,6 +11,14 @@ listen:
   addr: ":9999"   # CHANGE ME: Server listen port (must match network.ipv4.addr port)
                   # WARNING: Do not use standard ports (80, 443, etc.) as iptables rules
                   # can affect outgoing server connections.
+# Port Hopping Configuration (Optional)
+# Allows the server to receive connections across a range of ports.
+# Must match the client's configuration.
+hopping:
+  enabled: false      # Enable port hopping support
+  interval: 30        # Interval (unused on server, but good to keep consistent)
+  min: 20000          # Minimum port number to capture
+  max: 30000          # Maximum port number to capture
 
 # Network interface settings
 network:
@@ -86,6 +94,7 @@ transport:
     # smuxbuf: 4194304       # 4MB SMUX buffer
     # streambuf: 2097152     # 2MB stream buffer
 
+
 # Optional Forward Error Correction (FEC) - currently disabled
 # Use these only if you need FEC for very lossy networks:
 #   dshard: 10    # Data shards for FEC  
@@ -96,8 +105,10 @@ transport:
 # Since paqet uses pcap to bypass standard firewalls, you MUST configure
 # iptables on the server to prevent kernel interference:
 #
-# sudo iptables -t raw -A PREROUTING -p tcp --dport 9999 -j NOTRACK
-# sudo iptables -t raw -A OUTPUT -p tcp --sport 9999 -j NOTRACK  
-# sudo iptables -t mangle -A OUTPUT -p tcp --sport 9999 --tcp-flags RST RST -j DROP
+# sudo iptables -t raw -A PREROUTING -p tcp --dport 81 -j NOTRACK
+# sudo iptables -t raw -A OUTPUT -p tcp --sport 81 -j NOTRACK  
+# sudo iptables -t mangle -A OUTPUT -p tcp --sport 81 --tcp-flags RST RST -j DROP
 #
 # Replace 9999 with your actual listen port.
+# NOTE: If using Port Hopping, you must apply these rules to the entire port range 
+# (e.g., --dport 20000:30000).

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"paqet/internal/conf"
 	"paqet/internal/flog"
 	"paqet/internal/pkg/iterator"
@@ -53,6 +54,10 @@ func (c *Client) Start(ctx context.Context) error {
 	if c.cfg.Network.IPv6.Addr != nil {
 		ipv6Addr = c.cfg.Network.IPv6.Addr.IP.String()
 	}
-	flog.Infof("Client started: IPv4:%s IPv6:%s -> %s (%d connections)", ipv4Addr, ipv6Addr, c.cfg.Server.Addr, len(c.iter.Items))
+	dst := c.cfg.Server.Addr.String()
+	if c.cfg.Hopping.Enabled {
+		dst = fmt.Sprintf("%s (hopping: %d-%d)", c.cfg.Server.Addr.IP, c.cfg.Hopping.Min, c.cfg.Hopping.Max)
+	}
+	flog.Infof("Client started: IPv4:%s IPv6:%s -> %s (%d connections)", ipv4Addr, ipv6Addr, dst, len(c.iter.Items))
 	return nil
 }

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -19,6 +19,7 @@ type Conf struct {
 	Network   Network   `yaml:"network"`
 	Server    Server    `yaml:"server"`
 	Transport Transport `yaml:"transport"`
+	Hopping   Hopping   `yaml:"hopping"`
 }
 
 func LoadFromFile(path string) (*Conf, error) {
@@ -83,6 +84,7 @@ func (c *Conf) validate() error {
 
 	allErrors = append(allErrors, c.Network.validate()...)
 	allErrors = append(allErrors, c.Transport.validate()...)
+	allErrors = append(allErrors, c.Hopping.validate()...)
 	if c.Role == "server" {
 		allErrors = append(allErrors, c.Listen.validate()...)
 	} else {
@@ -109,4 +111,28 @@ func writeErr(allErrors []error) error {
 		return fmt.Errorf("validation failed:\n  - %s", strings.Join(messages, "\n  - "))
 	}
 	return nil
+}
+
+type Hopping struct {
+	Enabled  bool `yaml:"enabled"`
+	Interval int  `yaml:"interval"`
+	Min      int  `yaml:"min"`
+	Max      int  `yaml:"max"`
+}
+
+func (h *Hopping) validate() []error {
+	if !h.Enabled {
+		return nil
+	}
+	var errs []error
+	if h.Interval <= 0 {
+		errs = append(errs, fmt.Errorf("hopping interval must be > 0"))
+	}
+	if h.Min <= 0 || h.Max <= 0 {
+		errs = append(errs, fmt.Errorf("hopping ports must be > 0"))
+	}
+	if h.Min >= h.Max {
+		errs = append(errs, fmt.Errorf("hopping min port must be < max port"))
+	}
+	return errs
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -40,7 +40,7 @@ func (s *Server) Start() error {
 		cancel()
 	}()
 
-	pConn, err := socket.New(ctx, &s.cfg.Network)
+	pConn, err := socket.NewWithHopping(ctx, &s.cfg.Network, &s.cfg.Hopping, false)
 	if err != nil {
 		return fmt.Errorf("could not create raw packet conn: %w", err)
 	}
@@ -51,7 +51,11 @@ func (s *Server) Start() error {
 		return fmt.Errorf("could not start KCP listener: %w", err)
 	}
 	defer listener.Close()
-	flog.Infof("Server started - listening for packets on :%d", s.cfg.Listen.Addr.Port)
+	listenInfo := fmt.Sprintf(":%d", s.cfg.Listen.Addr.Port)
+	if s.cfg.Hopping.Enabled {
+		listenInfo = fmt.Sprintf("range %d-%d", s.cfg.Hopping.Min, s.cfg.Hopping.Max)
+	}
+	flog.Infof("Server started - listening for packets on %s", listenInfo)
 
 	s.wg.Go(func() {
 		s.listen(ctx, listener)


### PR DESCRIPTION
# feat: implement port hopping for evasion

## Description
This PR implements **Port Hopping**, a feature designed to evade detection mechanisms that flag long-lived connections on fixed ports. It allows the client to rotate destination ports periodically while the server listens on a range of ports.

## Key Changes

### 1. Configuration
*   **`internal/conf/conf.go`**: Added `Hopping` struct (`Enabled`, `Interval`, `Min`, `Max`).
*   **Examples**: Updated `client.yaml.example` and `server.yaml.example` with hopping configuration and required `iptables` rules for port ranges.

### 2. Client Implementation
*   **Dynamic Rotation**: The client (`internal/socket/socket.go`) now periodically rotates the destination port within the configured range.
*   **Forced Switching**: Logic ensures the new port is always different from the current one to prevent "hopping in place."
*   **KCP Normalization**: Incoming packets from the server are normalized to `hopping.min` in `ReadFrom` so the KCP session remains stable regardless of the actual reply port.

### 3. Server Implementation
*   **Range Listening**: The server's PCAP filter (`internal/socket/recv_handle.go`) now accepts traffic on the configured `portrange` instead of a single port.
*   **Port Echoing**: Implemented logic in `internal/socket/socket.go` to track which port a client used to contact the server. The server now replies from that exact same port (instead of the primary listen port) to ensure successful NAT traversal and firewall acceptance.

### 4. Low-Level Socket
*   **`RecvHandle.Read()`**: Updated to return the destination port of incoming packets.
*   **`SendHandle.Write()`**: Updated to accept a specific source port for outgoing packets.
*   **`cmd/ping/ping.go`**: Updated to support the new socket signature.

## Verification
*   [x] Verified traffic distribution across the configured port range using `tcpdump`.
*   [x] Verified server correctly echoes the port, allowing clients behind NAT to receive data.
*   [x] Verified `ping` command works with the updated socket signature.
*   [x] Verified multi-connection support (`conn: > 1`) works with hopping.
