### PR TITLE
internal/socket: fix zero-copy concurrent read buffer invalidation

### DIFF
--- a/internal/socket/recv_handle.go
+++ b/internal/socket/recv_handle.go
@@ -37,7 +37,7 @@ func NewRecvHandle(cfg *conf.Network) (*RecvHandle, error) {
 }
 
 func (h *RecvHandle) Read() ([]byte, net.Addr, error) {
-	data, _, err := h.handle.ZeroCopyReadPacketData()
+	data, _, err := h.handle.ReadPacketData()
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Replace `ZeroCopyReadPacketData` with `ReadPacketData` to prevent buffer invalidation under concurrent reads.