### PR TITLE
feat: IP-only packet transport layer

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -85,7 +85,9 @@ func (c *Conf) validate() error {
 	allErrors = append(allErrors, c.Transport.validate()...)
 	if c.Role == "server" {
 		allErrors = append(allErrors, c.Listen.validate()...)
-	} else {
+		c.Network.RPort = 0
+	}
+	if c.Role == "client" {
 		allErrors = append(allErrors, c.Server.validate()...)
 		if c.Server.Addr.IP.To4() != nil && c.Network.IPv4.Addr == nil {
 			allErrors = append(allErrors, fmt.Errorf("server address is IPv4, but the IPv4 interface is not configured"))
@@ -93,9 +95,10 @@ func (c *Conf) validate() error {
 		if c.Server.Addr.IP.To4() == nil && c.Network.IPv6.Addr == nil {
 			allErrors = append(allErrors, fmt.Errorf("server address is IPv6, but the IPv6 interface is not configured"))
 		}
-		if c.Transport.Conn > 1 && c.Network.Port != 0 {
+		if c.Transport.Conn > 1 && c.Network.LPort != 0 {
 			allErrors = append(allErrors, fmt.Errorf("only one connection is allowed when a client port is explicitly set"))
 		}
+		c.Network.RPort = c.Server.Addr.Port
 	}
 	return writeErr(allErrors)
 }

--- a/internal/conf/ip.go
+++ b/internal/conf/ip.go
@@ -1,0 +1,11 @@
+package conf
+
+type IP struct {
+	Protocol int `yaml:"protocol"`
+}
+
+func (i *IP) setDefaults() {
+	if i.Protocol == 0 {
+		i.Protocol = 6
+	}
+}

--- a/internal/conf/network.go
+++ b/internal/conf/network.go
@@ -18,15 +18,18 @@ type Network struct {
 	GUID       string         `yaml:"guid"`
 	IPv4       Addr           `yaml:"ipv4"`
 	IPv6       Addr           `yaml:"ipv6"`
-	PCAP       PCAP           `yaml:"pcap"`
+	IP         IP             `yaml:"ip"`
 	TCP        TCP            `yaml:"tcp"`
+	PCAP       PCAP           `yaml:"pcap"`
 	Interface  *net.Interface `yaml:"-"`
-	Port       int            `yaml:"-"`
+	LPort      int            `yaml:"-"`
+	RPort      int            `yaml:"-"`
 }
 
 func (n *Network) setDefaults(role string) {
 	n.PCAP.setDefaults(role)
 	n.TCP.setDefaults()
+	n.IP.setDefaults()
 }
 
 func (n *Network) validate() []error {
@@ -66,10 +69,10 @@ func (n *Network) validate() []error {
 		}
 	}
 	if n.IPv4.Addr != nil {
-		n.Port = n.IPv4.Addr.Port
+		n.LPort = n.IPv4.Addr.Port
 	}
 	if n.IPv6.Addr != nil {
-		n.Port = n.IPv6.Addr.Port
+		n.LPort = n.IPv6.Addr.Port
 	}
 
 	errors = append(errors, n.PCAP.validate()...)

--- a/internal/socket/recv_handle.go
+++ b/internal/socket/recv_handle.go
@@ -28,7 +28,7 @@ func NewRecvHandle(cfg *conf.Network) (*RecvHandle, error) {
 		}
 	}
 
-	filter := fmt.Sprintf("tcp and dst port %d", cfg.Port)
+	filter := fmt.Sprintf("ip proto %d", cfg.Port)
 	if err := handle.SetBPFFilter(filter); err != nil {
 		return nil, fmt.Errorf("failed to set BPF filter: %w", err)
 	}

--- a/internal/socket/recv_handle.go
+++ b/internal/socket/recv_handle.go
@@ -13,6 +13,8 @@ import (
 
 type RecvHandle struct {
 	handle *pcap.Handle
+	rPort  int
+	Read   func() ([]byte, net.Addr, error)
 }
 
 func NewRecvHandle(cfg *conf.Network) (*RecvHandle, error) {
@@ -20,23 +22,55 @@ func NewRecvHandle(cfg *conf.Network) (*RecvHandle, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open pcap handle: %w", err)
 	}
-
-	// SetDirection is not fully supported on Windows Npcap, so skip it
 	if runtime.GOOS != "windows" {
 		if err := handle.SetDirection(pcap.DirectionIn); err != nil {
 			return nil, fmt.Errorf("failed to set pcap direction in: %v", err)
 		}
 	}
 
-	filter := fmt.Sprintf("ip proto %d", cfg.Port)
+	rHandle := &RecvHandle{handle: handle}
+
+	var filter string
+	switch cfg.IP.Protocol {
+	case 6:
+		filter = fmt.Sprintf("tcp and dst port %d", cfg.LPort)
+		rHandle.Read = rHandle.ReadTCP
+	default:
+		filter = fmt.Sprintf("ip proto %d and not src host %s", cfg.IP.Protocol, cfg.IPv4.Addr.IP)
+		rHandle.rPort = cfg.RPort
+		rHandle.Read = rHandle.ReadIP
+	}
 	if err := handle.SetBPFFilter(filter); err != nil {
 		return nil, fmt.Errorf("failed to set BPF filter: %w", err)
 	}
 
-	return &RecvHandle{handle: handle}, nil
+	return rHandle, nil
 }
 
-func (h *RecvHandle) Read() ([]byte, net.Addr, error) {
+func (h *RecvHandle) ReadIP() ([]byte, net.Addr, error) {
+	data, _, err := h.handle.ReadPacketData()
+	if err != nil {
+		return nil, nil, err
+	}
+	p := gopacket.NewPacket(data, layers.LayerTypeEthernet, gopacket.NoCopy)
+
+	addr := &net.UDPAddr{Port: h.rPort}
+
+	netLayer := p.NetworkLayer()
+	if netLayer == nil {
+		return nil, nil, nil
+	}
+	switch netLayer.LayerType() {
+	case layers.LayerTypeIPv4:
+		addr.IP = netLayer.(*layers.IPv4).SrcIP
+	case layers.LayerTypeIPv6:
+		addr.IP = netLayer.(*layers.IPv6).SrcIP
+	}
+
+	return netLayer.LayerPayload(), addr, nil
+}
+
+func (h *RecvHandle) ReadTCP() ([]byte, net.Addr, error) {
 	data, _, err := h.handle.ReadPacketData()
 	if err != nil {
 		return nil, nil, err

--- a/internal/socket/send_handle.go
+++ b/internal/socket/send_handle.go
@@ -17,35 +17,43 @@ import (
 	"github.com/gopacket/gopacket/pcap"
 )
 
-type TCPF struct {
+type IP struct {
+	srcIPv4     net.IP
+	srcIPv4RHWA net.HardwareAddr
+	srcIPv6     net.IP
+	srcIPv6RHWA net.HardwareAddr
+	protocol    int
+}
+
+type tcpF struct {
 	tcpF       iterator.Iterator[conf.TCPF]
 	clientTCPF map[uint64]*iterator.Iterator[conf.TCPF]
 	mu         sync.RWMutex
 }
 
-type SendHandle struct {
-	handle      *pcap.Handle
-	srcIPv4     net.IP
-	srcIPv4RHWA net.HardwareAddr
-	srcIPv6     net.IP
-	srcIPv6RHWA net.HardwareAddr
-
-	ipProtocol int
-
+type TCP struct {
 	srcPort    uint16
 	synOptions []layers.TCPOption
 	ackOptions []layers.TCPOption
 	time       uint32
 	tsCounter  uint32
-	tcpF       TCPF
+	tcpF       *tcpF
+}
 
+type Pool struct {
 	ethPool  sync.Pool
 	ipv4Pool sync.Pool
 	ipv6Pool sync.Pool
 	tcpPool  sync.Pool
 	bufPool  sync.Pool
+}
 
-	Write func(payload []byte, addr *net.UDPAddr) error
+type SendHandle struct {
+	handle *pcap.Handle
+	ip     *IP
+	tcp    *TCP
+	pool   *Pool
+	Write  func(payload []byte, addr *net.UDPAddr) error
 }
 
 func NewSendHandle(cfg *conf.Network) (*SendHandle, error) {
@@ -61,31 +69,39 @@ func NewSendHandle(cfg *conf.Network) (*SendHandle, error) {
 		}
 	}
 
-	synOptions := []layers.TCPOption{
+	ip := &IP{protocol: cfg.IP.Protocol}
+	if cfg.IPv4.Addr != nil {
+		ip.srcIPv4 = cfg.IPv4.Addr.IP
+		ip.srcIPv4RHWA = cfg.IPv4.Router
+	}
+	if cfg.IPv6.Addr != nil {
+		ip.srcIPv6 = cfg.IPv6.Addr.IP
+		ip.srcIPv6RHWA = cfg.IPv6.Router
+	}
+
+	tcpf := &tcpF{
+		tcpF:       iterator.Iterator[conf.TCPF]{Items: cfg.TCP.LF},
+		clientTCPF: make(map[uint64]*iterator.Iterator[conf.TCPF]),
+	}
+	tcp := &TCP{
+		srcPort: uint16(cfg.LPort),
+		time:    uint32(time.Now().UnixNano() / int64(time.Millisecond)),
+		tcpF:    tcpf,
+	}
+	tcp.synOptions = []layers.TCPOption{
 		{OptionType: layers.TCPOptionKindMSS, OptionLength: 4, OptionData: []byte{0x05, 0xb4}},
 		{OptionType: layers.TCPOptionKindSACKPermitted, OptionLength: 2},
 		{OptionType: layers.TCPOptionKindTimestamps, OptionLength: 10, OptionData: make([]byte, 8)},
 		{OptionType: layers.TCPOptionKindNop},
 		{OptionType: layers.TCPOptionKindWindowScale, OptionLength: 3, OptionData: []byte{8}},
 	}
-
-	ackOptions := []layers.TCPOption{
+	tcp.ackOptions = []layers.TCPOption{
 		{OptionType: layers.TCPOptionKindNop},
 		{OptionType: layers.TCPOptionKindNop},
 		{OptionType: layers.TCPOptionKindTimestamps, OptionLength: 10, OptionData: make([]byte, 8)},
 	}
 
-	sh := &SendHandle{
-		handle: handle,
-
-		ipProtocol: cfg.IP.Protocol,
-
-		srcPort:    uint16(cfg.LPort),
-		synOptions: synOptions,
-		ackOptions: ackOptions,
-		tcpF:       TCPF{tcpF: iterator.Iterator[conf.TCPF]{Items: cfg.TCP.LF}, clientTCPF: make(map[uint64]*iterator.Iterator[conf.TCPF])},
-		time:       uint32(time.Now().UnixNano() / int64(time.Millisecond)),
-
+	pool := &Pool{
 		ethPool: sync.Pool{
 			New: func() any {
 				return &layers.Ethernet{SrcMAC: cfg.Interface.HardwareAddr}
@@ -112,13 +128,12 @@ func NewSendHandle(cfg *conf.Network) (*SendHandle, error) {
 			},
 		},
 	}
-	if cfg.IPv4.Addr != nil {
-		sh.srcIPv4 = cfg.IPv4.Addr.IP
-		sh.srcIPv4RHWA = cfg.IPv4.Router
-	}
-	if cfg.IPv6.Addr != nil {
-		sh.srcIPv6 = cfg.IPv6.Addr.IP
-		sh.srcIPv6RHWA = cfg.IPv6.Router
+
+	sh := &SendHandle{
+		handle: handle,
+		ip:     ip,
+		tcp:    tcp,
+		pool:   pool,
 	}
 
 	switch cfg.IP.Protocol {
@@ -132,7 +147,7 @@ func NewSendHandle(cfg *conf.Network) (*SendHandle, error) {
 }
 
 func (h *SendHandle) buildIPv4Header(dstIP net.IP, protocol int) *layers.IPv4 {
-	ip := h.ipv4Pool.Get().(*layers.IPv4)
+	ip := h.pool.ipv4Pool.Get().(*layers.IPv4)
 	*ip = layers.IPv4{
 		Version:  4,
 		IHL:      5,
@@ -140,40 +155,40 @@ func (h *SendHandle) buildIPv4Header(dstIP net.IP, protocol int) *layers.IPv4 {
 		TTL:      128,
 		Flags:    layers.IPv4DontFragment,
 		Protocol: layers.IPProtocol(protocol),
-		SrcIP:    h.srcIPv4,
+		SrcIP:    h.ip.srcIPv4,
 		DstIP:    dstIP,
 	}
 	return ip
 }
 
 func (h *SendHandle) buildIPv6Header(dstIP net.IP, protocol int) *layers.IPv6 {
-	ip := h.ipv6Pool.Get().(*layers.IPv6)
+	ip := h.pool.ipv6Pool.Get().(*layers.IPv6)
 	*ip = layers.IPv6{
 		Version:      6,
 		TrafficClass: 184,
 		HopLimit:     128,
 		NextHeader:   layers.IPProtocol(protocol),
-		SrcIP:        h.srcIPv6,
+		SrcIP:        h.ip.srcIPv6,
 		DstIP:        dstIP,
 	}
 	return ip
 }
 
 func (h *SendHandle) buildTCPHeader(dstPort uint16, f conf.TCPF) *layers.TCP {
-	tcp := h.tcpPool.Get().(*layers.TCP)
+	tcp := h.pool.tcpPool.Get().(*layers.TCP)
 	*tcp = layers.TCP{
-		SrcPort: layers.TCPPort(h.srcPort),
+		SrcPort: layers.TCPPort(h.tcp.srcPort),
 		DstPort: layers.TCPPort(dstPort),
 		FIN:     f.FIN, SYN: f.SYN, RST: f.RST, PSH: f.PSH, ACK: f.ACK, URG: f.URG, ECE: f.ECE, CWR: f.CWR, NS: f.NS,
 		Window: 65535,
 	}
 
-	counter := atomic.AddUint32(&h.tsCounter, 1)
-	tsVal := h.time + (counter >> 3)
+	counter := atomic.AddUint32(&h.tcp.tsCounter, 1)
+	tsVal := h.tcp.time + (counter >> 3)
 	if f.SYN {
-		binary.BigEndian.PutUint32(h.synOptions[2].OptionData[0:4], tsVal)
-		binary.BigEndian.PutUint32(h.synOptions[2].OptionData[4:8], 0)
-		tcp.Options = h.synOptions
+		binary.BigEndian.PutUint32(h.tcp.synOptions[2].OptionData[0:4], tsVal)
+		binary.BigEndian.PutUint32(h.tcp.synOptions[2].OptionData[4:8], 0)
+		tcp.Options = h.tcp.synOptions
 		tcp.Seq = 1 + (counter & 0x7)
 		tcp.Ack = 0
 		if f.ACK {
@@ -181,10 +196,10 @@ func (h *SendHandle) buildTCPHeader(dstPort uint16, f conf.TCPF) *layers.TCP {
 		}
 	} else {
 		tsEcr := tsVal - (counter%200 + 50)
-		binary.BigEndian.PutUint32(h.ackOptions[2].OptionData[0:4], tsVal)
-		binary.BigEndian.PutUint32(h.ackOptions[2].OptionData[4:8], tsEcr)
-		tcp.Options = h.ackOptions
-		seq := h.time + (counter << 7)
+		binary.BigEndian.PutUint32(h.tcp.ackOptions[2].OptionData[0:4], tsVal)
+		binary.BigEndian.PutUint32(h.tcp.ackOptions[2].OptionData[4:8], tsEcr)
+		tcp.Options = h.tcp.ackOptions
+		seq := h.tcp.time + (counter << 7)
 		tcp.Seq = seq
 		tcp.Ack = seq - (counter & 0x3FF) + 1400
 	}
@@ -193,28 +208,28 @@ func (h *SendHandle) buildTCPHeader(dstPort uint16, f conf.TCPF) *layers.TCP {
 }
 
 func (h *SendHandle) WriteIP(payload []byte, addr *net.UDPAddr) error {
-	buf := h.bufPool.Get().(gopacket.SerializeBuffer)
-	ethLayer := h.ethPool.Get().(*layers.Ethernet)
+	buf := h.pool.bufPool.Get().(gopacket.SerializeBuffer)
+	ethLayer := h.pool.ethPool.Get().(*layers.Ethernet)
 	defer func() {
 		buf.Clear()
-		h.bufPool.Put(buf)
-		h.ethPool.Put(ethLayer)
+		h.pool.bufPool.Put(buf)
+		h.pool.ethPool.Put(ethLayer)
 	}()
 
 	dstIP := addr.IP
 
 	var ipLayer gopacket.SerializableLayer
 	if dstIP.To4() != nil {
-		ip := h.buildIPv4Header(dstIP, h.ipProtocol)
-		defer h.ipv4Pool.Put(ip)
+		ip := h.buildIPv4Header(dstIP, h.ip.protocol)
+		defer h.pool.ipv4Pool.Put(ip)
 		ipLayer = ip
-		ethLayer.DstMAC = h.srcIPv4RHWA
+		ethLayer.DstMAC = h.ip.srcIPv4RHWA
 		ethLayer.EthernetType = layers.EthernetTypeIPv4
 	} else {
-		ip := h.buildIPv6Header(dstIP, h.ipProtocol)
-		defer h.ipv6Pool.Put(ip)
+		ip := h.buildIPv6Header(dstIP, h.ip.protocol)
+		defer h.pool.ipv6Pool.Put(ip)
 		ipLayer = ip
-		ethLayer.DstMAC = h.srcIPv6RHWA
+		ethLayer.DstMAC = h.ip.srcIPv6RHWA
 		ethLayer.EthernetType = layers.EthernetTypeIPv6
 	}
 
@@ -227,12 +242,12 @@ func (h *SendHandle) WriteIP(payload []byte, addr *net.UDPAddr) error {
 }
 
 func (h *SendHandle) WriteTCP(payload []byte, addr *net.UDPAddr) error {
-	buf := h.bufPool.Get().(gopacket.SerializeBuffer)
-	ethLayer := h.ethPool.Get().(*layers.Ethernet)
+	buf := h.pool.bufPool.Get().(gopacket.SerializeBuffer)
+	ethLayer := h.pool.ethPool.Get().(*layers.Ethernet)
 	defer func() {
 		buf.Clear()
-		h.bufPool.Put(buf)
-		h.ethPool.Put(ethLayer)
+		h.pool.bufPool.Put(buf)
+		h.pool.ethPool.Put(ethLayer)
 	}()
 
 	dstIP := addr.IP
@@ -240,22 +255,22 @@ func (h *SendHandle) WriteTCP(payload []byte, addr *net.UDPAddr) error {
 
 	f := h.getClientTCPF(dstIP, dstPort)
 	tcpLayer := h.buildTCPHeader(dstPort, f)
-	defer h.tcpPool.Put(tcpLayer)
+	defer h.pool.tcpPool.Put(tcpLayer)
 
 	var ipLayer gopacket.SerializableLayer
 	if dstIP.To4() != nil {
-		ip := h.buildIPv4Header(dstIP, h.ipProtocol)
-		defer h.ipv4Pool.Put(ip)
+		ip := h.buildIPv4Header(dstIP, h.ip.protocol)
+		defer h.pool.ipv4Pool.Put(ip)
 		ipLayer = ip
 		tcpLayer.SetNetworkLayerForChecksum(ip)
-		ethLayer.DstMAC = h.srcIPv4RHWA
+		ethLayer.DstMAC = h.ip.srcIPv4RHWA
 		ethLayer.EthernetType = layers.EthernetTypeIPv4
 	} else {
-		ip := h.buildIPv6Header(dstIP, h.ipProtocol)
-		defer h.ipv6Pool.Put(ip)
+		ip := h.buildIPv6Header(dstIP, h.ip.protocol)
+		defer h.pool.ipv6Pool.Put(ip)
 		ipLayer = ip
 		tcpLayer.SetNetworkLayerForChecksum(ip)
-		ethLayer.DstMAC = h.srcIPv6RHWA
+		ethLayer.DstMAC = h.ip.srcIPv6RHWA
 		ethLayer.EthernetType = layers.EthernetTypeIPv6
 	}
 
@@ -267,19 +282,19 @@ func (h *SendHandle) WriteTCP(payload []byte, addr *net.UDPAddr) error {
 }
 
 func (h *SendHandle) getClientTCPF(dstIP net.IP, dstPort uint16) conf.TCPF {
-	h.tcpF.mu.RLock()
-	defer h.tcpF.mu.RUnlock()
-	if ff := h.tcpF.clientTCPF[hash.IPAddr(dstIP, dstPort)]; ff != nil {
+	h.tcp.tcpF.mu.RLock()
+	defer h.tcp.tcpF.mu.RUnlock()
+	if ff := h.tcp.tcpF.clientTCPF[hash.IPAddr(dstIP, dstPort)]; ff != nil {
 		return ff.Next()
 	}
-	return h.tcpF.tcpF.Next()
+	return h.tcp.tcpF.tcpF.Next()
 }
 
 func (h *SendHandle) setClientTCPF(addr net.Addr, f []conf.TCPF) {
 	a := *addr.(*net.UDPAddr)
-	h.tcpF.mu.Lock()
-	h.tcpF.clientTCPF[hash.IPAddr(a.IP, uint16(a.Port))] = &iterator.Iterator[conf.TCPF]{Items: f}
-	h.tcpF.mu.Unlock()
+	h.tcp.tcpF.mu.Lock()
+	h.tcp.tcpF.clientTCPF[hash.IPAddr(a.IP, uint16(a.Port))] = &iterator.Iterator[conf.TCPF]{Items: f}
+	h.tcp.tcpF.mu.Unlock()
 }
 
 func (h *SendHandle) Close() {

--- a/internal/socket/socket.go
+++ b/internal/socket/socket.go
@@ -24,8 +24,8 @@ type PacketConn struct {
 
 // &OpError{Op: "listen", Net: network, Source: nil, Addr: nil, Err: err}
 func New(ctx context.Context, cfg *conf.Network) (*PacketConn, error) {
-	if cfg.Port == 0 {
-		cfg.Port = 32768 + rand.Intn(32768)
+	if cfg.LPort == 0 {
+		cfg.LPort = 32768 + rand.Intn(32768)
 	}
 
 	sendHandle, err := NewSendHandle(cfg)

--- a/internal/tnet/kcp/kcp.go
+++ b/internal/tnet/kcp/kcp.go
@@ -1,6 +1,7 @@
 package kcp
 
 import (
+	"fmt"
 	"paqet/internal/conf"
 	"time"
 
@@ -35,6 +36,16 @@ func aplConf(conn *kcp.UDPSession, cfg *conf.KCP) {
 	conn.SetWriteDelay(wDelay)
 	conn.SetACKNoDelay(ackNoDelay)
 	conn.SetDSCP(46)
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		for range ticker.C {
+			snmp := kcp.DefaultSnmp.Copy()
+			fmt.Printf("[KCP Stats] InPkts=%d OutPkts=%d InSegs=%d OutSegs=%d RetransSegs=%d\n",
+				snmp.InPkts, snmp.OutPkts, snmp.InSegs, snmp.OutSegs, snmp.RetransSegs)
+		}
+	}()
+
 }
 
 func smuxConf(cfg *conf.KCP) *smux.Config {

--- a/internal/tnet/kcp/kcp.go
+++ b/internal/tnet/kcp/kcp.go
@@ -1,7 +1,6 @@
 package kcp
 
 import (
-	"fmt"
 	"paqet/internal/conf"
 	"time"
 
@@ -36,16 +35,15 @@ func aplConf(conn *kcp.UDPSession, cfg *conf.KCP) {
 	conn.SetWriteDelay(wDelay)
 	conn.SetACKNoDelay(ackNoDelay)
 	conn.SetDSCP(46)
-	go func() {
-		ticker := time.NewTicker(5 * time.Second)
-		defer ticker.Stop()
-		for range ticker.C {
-			snmp := kcp.DefaultSnmp.Copy()
-			fmt.Printf("[KCP Stats] InPkts=%d OutPkts=%d InSegs=%d OutSegs=%d RetransSegs=%d\n",
-				snmp.InPkts, snmp.OutPkts, snmp.InSegs, snmp.OutSegs, snmp.RetransSegs)
-		}
-	}()
-
+	// go func() {
+	// 	ticker := time.NewTicker(5 * time.Second)
+	// 	defer ticker.Stop()
+	// 	for range ticker.C {
+	// 		snmp := kcp.DefaultSnmp.Copy()
+	// 		fmt.Printf("[KCP Stats] InPkts=%d OutPkts=%d InSegs=%d OutSegs=%d RetransSegs=%d\n",
+	// 			snmp.InPkts, snmp.OutPkts, snmp.InSegs, snmp.OutSegs, snmp.RetransSegs)
+	// 	}
+	// }()
 }
 
 func smuxConf(cfg *conf.KCP) *smux.Config {


### PR DESCRIPTION
this feature adds IP-only packet transport. to use it, set an IP protocol number in the network section on both client and server. no TCP, UDP, or other layers are involved.

**Note: this requires a public IP on both client and server and will not work behind NAT.**

all other options remain the same.
```yaml
network:
  interface: "eth0"
  ip:
    protocol: 253
```

to prevent kernel interference, run the following on both client and server
```bash
sudo iptables -A INPUT -p 253 -j DROP
sudo iptables -A OUTPUT -p 253 -j DROP
```
