### PR TITLE
feat(server): add optional SOCKS5 outbound for TCP/UDP backend connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ log:
 listen:
   addr: ":9999" # CHANGE ME: Server listen port (must match network.ipv4.addr port), WARNING: Do not use standard ports (80, 443, etc.) as iptables rules can affect outgoing server connections.
 
+# Outbound configuration (optional)
+# outbound:
+#   type: "direct"                           # or "socks5" to route TCP/UDP via proxy
+#   addr: "proxy.example.com:1080"           # required when type is socks5
+#   username: ""                             # optional
+#   password: ""                             # optional
+
 # Network interface settings
 network:
   interface: "eth0" # CHANGE ME: Network interface (eth0, ens3, en0, etc.)

--- a/example/server.yaml.example
+++ b/example/server.yaml.example
@@ -12,6 +12,13 @@ listen:
                   # WARNING: Do not use standard ports (80, 443, etc.) as iptables rules
                   # can affect outgoing server connections.
 
+# Outbound configuration (optional - omit for direct; use type: socks5 for proxy)
+# outbound:
+#   type: "direct"                           # or "socks5"
+#   addr: "proxy.example.com:1080"           # required when type is socks5
+#   username: ""                             # optional
+#   password: ""                             # optional
+
 # Network interface settings
 network:
   interface: "eth0"                          # CHANGE ME: Network interface (eth0, ens3, en0, etc.)

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -14,6 +14,7 @@ type Conf struct {
 	Role      string    `yaml:"role"`
 	Log       Log       `yaml:"log"`
 	Listen    Server    `yaml:"listen"`
+	Outbound  Outbound  `yaml:"outbound"`
 	SOCKS5    []SOCKS5  `yaml:"socks5"`
 	Forward   []Forward `yaml:"forward"`
 	Network   Network   `yaml:"network"`
@@ -49,6 +50,7 @@ func LoadFromFile(path string) (*Conf, error) {
 func (c *Conf) setDefaults() {
 	c.Log.setDefaults()
 	c.Listen.setDefaults()
+	c.Outbound.setDefaults()
 	for i := range c.SOCKS5 {
 		c.SOCKS5[i].setDefaults()
 	}
@@ -85,6 +87,9 @@ func (c *Conf) validate() error {
 	allErrors = append(allErrors, c.Transport.validate()...)
 	if c.Role == "server" {
 		allErrors = append(allErrors, c.Listen.validate()...)
+		for _, err := range c.Outbound.validate() {
+			allErrors = append(allErrors, err)
+		}
 	} else {
 		allErrors = append(allErrors, c.Server.validate()...)
 		if c.Server.Addr.IP.To4() != nil && c.Network.IPv4.Addr == nil {

--- a/internal/conf/outbound.go
+++ b/internal/conf/outbound.go
@@ -1,0 +1,51 @@
+package conf
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+type Outbound struct {
+	Type_    string `yaml:"type"`
+	Addr_    string `yaml:"addr"`
+	Username string `yaml:"username"`
+	Password string `yaml:"password"`
+
+	Type string `yaml:"-"`
+	Addr string `yaml:"-"`
+}
+
+func (o *Outbound) setDefaults() {
+	if o.Type_ == "" {
+		o.Type = "direct"
+	} else {
+		o.Type = strings.ToLower(strings.TrimSpace(o.Type_))
+	}
+}
+
+func (o *Outbound) validate() []error {
+	var errors []error
+
+	if o.Type == "" {
+		o.Type = "direct"
+	}
+	if o.Type != "direct" && o.Type != "socks5" {
+		errors = append(errors, fmt.Errorf("outbound type must be 'direct' or 'socks5', got %q", o.Type))
+	}
+	if o.Type == "socks5" {
+		addr := strings.TrimSpace(o.Addr_)
+		if addr == "" {
+			errors = append(errors, fmt.Errorf("outbound addr is required when type is socks5"))
+		} else {
+			addr = strings.TrimPrefix(addr, "socks5://")
+			_, err := net.ResolveTCPAddr("tcp", addr)
+			if err != nil {
+				errors = append(errors, fmt.Errorf("outbound addr invalid: %w", err))
+			} else {
+				o.Addr = addr
+			}
+		}
+	}
+	return errors
+}

--- a/internal/server/dialer.go
+++ b/internal/server/dialer.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/txthinking/socks5"
+)
+
+type Dialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+type directDialer struct {
+	d *net.Dialer
+}
+
+func (d *directDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return d.d.DialContext(ctx, network, address)
+}
+
+func newDirectDialer() Dialer {
+	return &directDialer{
+		d: &net.Dialer{Timeout: 10 * time.Second},
+	}
+}
+
+type socks5Dialer struct {
+	client *socks5.Client
+}
+
+func (d *socks5Dialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	type result struct {
+		conn net.Conn
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		conn, err := d.client.Dial(network, address)
+		done <- result{conn, err}
+	}()
+	select {
+	case res := <-done:
+		if res.err != nil {
+			return nil, res.err
+		}
+		select {
+		case <-ctx.Done():
+			res.conn.Close()
+			return nil, ctx.Err()
+		default:
+			return res.conn, nil
+		}
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func newSOCKS5Dialer(addr, username, password string) (Dialer, error) {
+	client, err := socks5.NewClient(addr, username, password, 10, 10)
+	if err != nil {
+		return nil, err
+	}
+	return &socks5Dialer{client: client}, nil
+}

--- a/internal/server/tcp.go
+++ b/internal/server/tcp.go
@@ -2,12 +2,10 @@ package server
 
 import (
 	"context"
-	"net"
 	"paqet/internal/flog"
 	"paqet/internal/pkg/buffer"
 	"paqet/internal/protocol"
 	"paqet/internal/tnet"
-	"time"
 )
 
 func (s *Server) handleTCPProtocol(ctx context.Context, strm tnet.Strm, p *protocol.Proto) error {
@@ -16,8 +14,7 @@ func (s *Server) handleTCPProtocol(ctx context.Context, strm tnet.Strm, p *proto
 }
 
 func (s *Server) handleTCP(ctx context.Context, strm tnet.Strm, addr string) error {
-	dialer := &net.Dialer{Timeout: 10 * time.Second}
-	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	conn, err := s.dialer.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		flog.Errorf("failed to establish TCP connection to %s for stream %d: %v", addr, strm.SID(), err)
 		return err

--- a/internal/server/udp.go
+++ b/internal/server/udp.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"net"
 	"paqet/internal/flog"
 	"paqet/internal/pkg/buffer"
 	"paqet/internal/protocol"
@@ -15,7 +14,7 @@ func (s *Server) handleUDPProtocol(ctx context.Context, strm tnet.Strm, p *proto
 }
 
 func (s *Server) handleUDP(ctx context.Context, strm tnet.Strm, addr string) error {
-	conn, err := net.Dial("udp", addr)
+	conn, err := s.dialer.DialContext(ctx, "udp", addr)
 	if err != nil {
 		flog.Errorf("failed to establish UDP connection to %s for stream %d: %v", addr, strm.SID(), err)
 		return err


### PR DESCRIPTION
## Title
**feat(server): add optional SOCKS5 outbound for TCP/UDP backend connections**

---

## Description

### Summary
Adds an optional **outbound** block to server configuration so the server can route all backend TCP and UDP connections through a SOCKS5 proxy. This enables **proxy chaining**: the paqet server can sit in front of another proxy (e.g. Cloudflare WARP, Xray, or a corporate SOCKS5 proxy), so traffic flows **Client → paqet → SOCKS5 outbound → WARP/Xray/… → Internet**. You can combine paqet’s raw-packet transport with Xray, or any SOCKS5-capable proxy at the end of the chain.

### Changes

**Configuration (`internal/conf/outbound.go`)**
- New `Outbound` struct: `type` (`direct` | `socks5`), `addr` (required for `socks5`), optional `username`/`password`.
- Validation: `type` must be `direct` or `socks5`; for `socks5`, `addr` is required and must be a valid TCP address (optional `socks5://` prefix stripped).
- Default: `type: direct` when outbound is omitted or type is empty.

**Server dialer (`internal/server/dialer.go`)**
- New `Dialer` interface: `DialContext(ctx, network, address) (net.Conn, error)`.
- **Direct dialer:** wraps `net.Dialer` (10s timeout); used when `outbound.type` is `direct` or unset.
- **SOCKS5 dialer:** uses `github.com/txthinking/socks5`; connects to the proxy and performs CONNECT for TCP / UDP relay. Respects `context` cancellation (dial in goroutine + select on `ctx.Done()`).

**Server wiring**
- `internal/server/server.go`: In `New()`, chooses dialer from `cfg.Outbound.Type` (socks5 vs direct) and stores it on the server.
- `internal/server/tcp.go`: Uses `s.dialer.DialContext(ctx, "tcp", addr)` for backend TCP.
- `internal/server/udp.go`: Uses `s.dialer.DialContext(ctx, "udp", addr)` for backend UDP.

**Documentation**
- **README:** Example server config updated with commented `outbound` block (type, addr, username, password) and note about routing TCP/UDP via proxy.
- **example/server.yaml.example:** Same outbound example and comment style.
