### PR TITLE
musl Build Workflow for OpenWRT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,7 +230,7 @@ jobs:
                   path: dist/paqet-darwin-${{ matrix.goarch }}-${{ steps.ref_id.outputs.ref }}.tar.gz
                   retention-days: 1
   
-      build-openwrt-musl:
+    build-openwrt-musl:
         runs-on: ubuntu-latest
         strategy:
           matrix:


### PR DESCRIPTION
Summary
OpenWrt build support using musl libc for ARM-based routers and embedded devices.

Changes
Added build-musl-openwrt job to .github/workflows/build.yml using QEMU.
for:
linux/arm64 → OpenWrt ARM64 devices
linux/arm/v7 → OpenWrt ARM32 devices (ARMv7)


CGO: Enabled for libpcap support
QEMU: Multi-arch emulation for cross-platform builds

Build Artifacts:
paqet-openwrt-musl-arm64-{version}.tar.gz
paqet-openwrt-musl-arm32-{version}.tar.gz

Each tarball includes:
Compiled binary
README.md
Example configuration files

Tested On:
Arm64 build tested on Openwrt Nokia FastMile 5G WiFi Gateway 3.2