### PR TITLE
iterator: fix off-by-one to start iteration from index 0

### DIFF
--- a/internal/pkg/iterator/iterator.go
+++ b/internal/pkg/iterator/iterator.go
@@ -8,7 +8,7 @@ type Iterator[T any] struct {
 }
 
 func (it *Iterator[T]) Next() T {
-	i := it.index.Add(1)
+	i := it.index.Add(1) - 1
 	n := uint64(len(it.Items))
 	if n&(n-1) == 0 {
 		return it.Items[i&(n-1)]


### PR DESCRIPTION
Hello,
Recently, I was reviewing the `paqet` project for fun, and I faced this line. It's a tiny fix on the Iterator's Next method to start from the first index of the Items list.
Hope it can help.
