### PR TITLE
fix: prevent tcpf leak and replace blocking pcap read with timeout loop

### DIFF
--- a/internal/client/dial.go
+++ b/internal/client/dial.go
@@ -11,7 +11,6 @@ func (c *Client) newConn() (tnet.Conn, error) {
 	defer c.mu.Unlock()
 	autoExpire := 300
 	tc := c.iter.Next()
-	go tc.sendTCPF(tc.conn)
 	err := tc.conn.Ping(false)
 	if err != nil {
 		flog.Infof("connection lost, retrying....")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -82,6 +82,9 @@ func (s *Server) listen(ctx context.Context, listener tnet.Listener) {
 
 		s.wg.Go(func() {
 			defer conn.Close()
+			// Drop the per-client TCPF entry when the session ends; otherwise
+			// every reconnect (new source port) leaks a map entry forever.
+			defer s.pConn.DeleteClientTCPF(conn.RemoteAddr())
 			s.handleConn(ctx, conn)
 		})
 	}

--- a/internal/socket/handle.go
+++ b/internal/socket/handle.go
@@ -4,9 +4,18 @@ import (
 	"fmt"
 	"paqet/internal/conf"
 	"runtime"
+	"time"
 
 	"github.com/gopacket/gopacket/pcap"
 )
+
+// readTimeout keeps the pcap handle in non-blocking mode. A positive timeout
+// makes gopacket's Activate() call setNonBlocking(), so pcap_next_ex polls
+// instead of parking in the kernel forever. That lets Handle.Close() interrupt
+// an idle read loop (via its stop flag); with pcap.BlockForever a read on a
+// now-silent source (e.g. after a reconnect) never returns, so Close() hangs
+// and the capture buffer plus read-loop goroutine leak on every reconnect.
+const readTimeout = 100 * time.Millisecond
 
 func newHandle(cfg *conf.Network) (*pcap.Handle, error) {
 	// On Windows, use the GUID field to construct the NPF device name
@@ -32,7 +41,7 @@ func newHandle(cfg *conf.Network) (*pcap.Handle, error) {
 	if err = inactive.SetPromisc(true); err != nil {
 		return nil, fmt.Errorf("failed to enable promiscuous mode: %v", err)
 	}
-	if err = inactive.SetTimeout(pcap.BlockForever); err != nil {
+	if err = inactive.SetTimeout(readTimeout); err != nil {
 		return nil, fmt.Errorf("failed to set pcap timeout: %v", err)
 	}
 	if err = inactive.SetImmediateMode(true); err != nil {

--- a/internal/socket/send_handle.go
+++ b/internal/socket/send_handle.go
@@ -222,6 +222,16 @@ func (h *SendHandle) setClientTCPF(addr net.Addr, f []conf.TCPF) {
 	h.tcpF.mu.Unlock()
 }
 
+func (h *SendHandle) deleteClientTCPF(addr net.Addr) {
+	a, ok := addr.(*net.UDPAddr)
+	if !ok {
+		return
+	}
+	h.tcpF.mu.Lock()
+	delete(h.tcpF.clientTCPF, hash.IPAddr(a.IP, uint16(a.Port)))
+	h.tcpF.mu.Unlock()
+}
+
 func (h *SendHandle) Close() {
 	if h.handle != nil {
 		h.handle.Close()

--- a/internal/socket/socket.go
+++ b/internal/socket/socket.go
@@ -2,6 +2,7 @@ package socket
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -9,6 +10,8 @@ import (
 	"paqet/internal/conf"
 	"sync/atomic"
 	"time"
+
+	"github.com/gopacket/gopacket/pcap"
 )
 
 type PacketConn struct {
@@ -59,21 +62,26 @@ func (c *PacketConn) ReadFrom(data []byte) (n int, addr net.Addr, err error) {
 		deadline = timer.C
 	}
 
-	select {
-	case <-c.ctx.Done():
-		return 0, nil, c.ctx.Err()
-	case <-deadline:
-		return 0, nil, os.ErrDeadlineExceeded
-	default:
-	}
+	for {
+		select {
+		case <-c.ctx.Done():
+			return 0, nil, c.ctx.Err()
+		case <-deadline:
+			return 0, nil, os.ErrDeadlineExceeded
+		default:
+		}
 
-	payload, addr, err := c.recvHandle.Read()
-	if err != nil {
-		return 0, nil, err
+		payload, paddr, perr := c.recvHandle.Read()
+		if perr != nil {
+			// Idle poll timeout on the non-blocking handle: not a real error,
+			// loop back to re-check ctx/deadline so the read stays cancelable.
+			if errors.Is(perr, pcap.NextErrorTimeoutExpired) {
+				continue
+			}
+			return 0, nil, perr
+		}
+		return copy(data, payload), paddr, nil
 	}
-	n = copy(data, payload)
-
-	return n, addr, nil
 }
 
 func (c *PacketConn) WriteTo(data []byte, addr net.Addr) (n int, err error) {
@@ -150,4 +158,8 @@ func (c *PacketConn) SetDSCP(dscp int) error {
 
 func (c *PacketConn) SetClientTCPF(addr net.Addr, f []conf.TCPF) {
 	c.sendHandle.setClientTCPF(addr, f)
+}
+
+func (c *PacketConn) DeleteClientTCPF(addr net.Addr) {
+	c.sendHandle.deleteClientTCPF(addr)
 }


### PR DESCRIPTION
Client RSS grew linearly with every reconnect.

The pcap capture handle was activated with `pcap.BlockForever`, which leaves it in blocking mode — `pcap_next_ex` parks in the kernel and never checks the stop flag set by `Handle.Close()`. After a reconnect the old source port goes silent, so that read never returns, `Close()` hangs, and `pcap_close()` is never called. Each reconnect leaked the recv capture buffer plus the read-loop goroutine (which pinned the old kcp/smux session from GC).

A second, server-side leak: the `clientTCPF` map gained one entry per client source port and never released it, growing without bound as clients reconnected.

## Changes
- Activate the handle with a finite read timeout so it runs non-blocking and `Close()` can interrupt an idle read; loop in `ReadFrom` over poll timeouts while staying cancelable via context/deadline.
- Prune the server `clientTCPF` entry when a session ends.
- Drop the redundant `sendTCPF` on every `newConn` — the config is already sent once at connection setup.